### PR TITLE
Make libnotify optional when notifications are disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,9 @@ find_package(GTest)
 find_package(PkgConfig REQUIRED)
 find_package(TBB REQUIRED)
 pkg_check_modules(READLINE REQUIRED readline)
-pkg_check_modules(LIBNOTIFY REQUIRED IMPORTED_TARGET libnotify)
+if(ENABLE_NOTIFICATIONS)
+    pkg_check_modules(LIBNOTIFY REQUIRED IMPORTED_TARGET libnotify)
+endif()
 
 # Optional dependencies
 find_package(nlohmann_json QUIET)
@@ -204,7 +206,8 @@ if(ENABLE_NOTIFICATIONS)
     target_link_libraries(cpprepl_lib PUBLIC PkgConfig::LIBNOTIFY)
     target_compile_definitions(cpprepl_lib PUBLIC ENABLE_NOTIFICATIONS)
 else()
-    message(STATUS "✗ Desktop notifications disabled")
+    message(STATUS "✗ Desktop notifications disabled (reconfigure with -DENABLE_NOTIFICATIONS=ON to enable libnotify support)")
+    target_compile_definitions(cpprepl_lib PUBLIC NUSELIBNOTIFY)
 endif()
 
 # ==============================================================================

--- a/repl.cpp
+++ b/repl.cpp
@@ -34,7 +34,9 @@
 #include <fstream>
 #include <functional>
 #include <future>
+#ifndef NUSELIBNOTIFY
 #include <libnotify/notify.h>
+#endif
 #include <mutex>
 #include <readline/history.h>
 #include <readline/readline.h>


### PR DESCRIPTION
## Summary
- wrap the libnotify pkg-config lookup in an ENABLE_NOTIFICATIONS guard
- emit a status hint and define NUSELIBNOTIFY when notifications are disabled so the code builds without libnotify
- guard the direct libnotify include in repl.cpp so builds succeed when notifications are off

## Testing
- cmake -S . -B build -DENABLE_NOTIFICATIONS=OFF
- cmake --build build --parallel
- ctest --output-on-failure --parallel $(nproc)


------
https://chatgpt.com/codex/tasks/task_e_68cf48aa91788326890ae82d27365e63