### PR TITLE
Run workflow CMake build in parallel

### DIFF
--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -52,7 +52,7 @@ jobs:
 
     - name: Build
       # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel $(nproc)
 
     - name: Test
       working-directory: ${{github.workspace}}/build


### PR DESCRIPTION
## Summary
- update the GitHub Actions build step to pass --parallel with nproc when invoking cmake

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf566b812c8326ae407d545266cd72