### PR TITLE
Fix export flag handling in CompilerService link step

### DIFF
--- a/src/compiler/compiler_service.cpp
+++ b/src/compiler/compiler_service.cpp
@@ -402,10 +402,11 @@ CompilerService::linkObjects(const std::vector<std::string> &objects,
                              const std::string &libname) const {
     std::string linkLibraries = getLinkLibrariesStr();
     std::string namesConcated = concatenateNames(objects);
+    std::string extraLinkerFlags = buildSettings_->getExtraLinkerFlags();
 
     std::string cmd =
-        std::format("clang++ -shared -g -WL,--export-dynamic {} {} -o lib{}.so",
-                    namesConcated, linkLibraries, libname);
+        std::format("clang++ -shared -g -Wl,--export-dynamic {} {} {} -o lib{}.so",
+                    namesConcated, linkLibraries, extraLinkerFlags, libname);
 
     return executeCommand(cmd);
 }


### PR DESCRIPTION
## Summary
- ensure CompilerService uses the correct lowercase linker flag `-Wl,--export-dynamic`
- append any extra linker flags from the build settings when linking generated objects

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `printf "int foo(){return 123;}\nfoo();\nexit\n" | ./build/cpprepl -v`


------
https://chatgpt.com/codex/tasks/task_e_68cf5f8787cc832691ad4b2d2d4ce82e